### PR TITLE
Default retry error strategy

### DIFF
--- a/config/modules.config
+++ b/config/modules.config
@@ -12,86 +12,56 @@
 
 //process configurations
 process {
-    memory: '1G'
+    queue = 'regular'
+
+    // Retry any failing task up to 5 times by default
+    maxRetries = 5
+    errorStrategy = 'retry'
+
     withLabel:BWAAlign {
-        queue='regular'
         cpus = 5
-        memory={ 4.GB * task.attempt }
-        time='12h'
-        errorStrategy ={ 'retry'  }
-        maxRetries= 5
+        memory = { 4.GB * task.attempt }
+        time = '12h'
     }
     withLabel:IndexDedup {
-        queue='regular'
         cpus = 5
-        memory={ 32.GB * task.attempt }
-        time='8h'
-        errorStrategy ={ 'retry'  }
-        maxRetries= 5
+        memory = { 32.GB * task.attempt }
+        time = '8h'
     }
     withLabel:Write {
-        queue='regular'
         cpus = 1
-        memory={ 1.GB * task.attempt }
-        time='12h'
-        //errorStrategy ={ 'retry'  }
-        maxRetries= 5
+        memory = { 1.GB * task.attempt }
+        time = '12h'
+        errorStrategy = 'terminate'
     }
     withLabel:Samtools {
-        queue='regular'
         cpus = 1
-        memory={ 8.GB * task.attempt }
-        errorStrategy ={ 'retry'  }
-        maxRetries= 5
+        memory = { 8.GB * task.attempt }
     }
     withLabel:Bcftools {
-        queue='regular'
         cpus = 5
-        memory={ 8.GB * task.attempt }
-        time='12h'
-
-        //errorStrategy ={ 'retry'  }
-        maxRetries= 5
+        memory = { 8.GB * task.attempt }
+        time = '12h'
+        errorStrategy = 'terminate'
     }
     withLabel: Fastqc {
-        queue='regular'
         cpus = 5
-        memory={ 4.GB * task.attempt }
-        time='12h'
-
-        errorStrategy ={ 'retry'  }
-        maxRetries= 5
+        memory = { 4.GB * task.attempt }
+        time = '12h'
     }
     withLabel: Multiqc {
-        queue='regular'
         cpus = 2
-        memory={ 1.GB * task.attempt }
+        memory = { 1.GB * task.attempt }
         time='12h'
-
-        errorStrategy ={ 'retry'  }
-        maxRetries= 5
     }
     withLabel: Gridss {
-        queue='regular'
         cpus = 8
-        time='12h'
-        memory={ 20.GB * task.attempt }
-
-        errorStrategy ={ 'retry'  }
-        maxRetries= 5
+        time = '12h'
+        memory = { 20.GB * task.attempt }
     }
     withLabel: Rfilter {
-        queue='regular'
         cpus = 8
-        time='12h'
-        memory={ 10.GB * task.attempt }
-
-        errorStrategy ={ 'retry'  }
-        maxRetries= 5
+        time = '12h'
+        memory = { 10.GB * task.attempt }
     }
-    
-    
-   
-    
-    
 }


### PR DESCRIPTION
I haven't tested this, nor have I consulted with the others, so worth testing this first.

My guess is that retries aren't working at the moment, because the following is the correct way to enable retries:
```groovy
errorStrategy = 'retry'
```

I also refactored some other settings to apply to all processes by default, in order to simplify things.