### PR TITLE
Calculate small-variant Allele Frequencies using AD & DP

### DIFF
--- a/Rtools/malDrugR/filterBcfVcf.R
+++ b/Rtools/malDrugR/filterBcfVcf.R
@@ -60,16 +60,20 @@ pfCurrRefs <- data.frame(
   version = c("52", "57", "52")
 )
 ref <- filter(pfCurrRefs, strain == argv$refstrain)
-if (ref$strain == "Supp"){
+if (ref$strain == "Supp") {
   ref$strain <- "3D7"
   ref$supp <- "_supplemented"
-  } else ref$supp <- ""
+} else {
+  ref$supp <- ""
+}
 
 # ---------- Read genomic features --------------------------------------------
 file.gff <- file.path(
   refDir,
-  paste0("PlasmoDB-", ref$version, "_Pfalciparum", ref$strain, ref$supp,
-         ".gff")
+  paste0(
+    "PlasmoDB-", ref$version, "_Pfalciparum", ref$strain, ref$supp,
+    ".gff"
+  )
 )
 
 pf_features <- tryCatch(
@@ -97,7 +101,7 @@ CDSnoVar <- pf_featuresNovar[annotation(pf_featuresNovar)$type == "CDS", ]
 file.chrinfo <- file.path(
   refDir, paste0(
     "PlasmoDB-", ref$version, "_Pfalciparum", ref$strain,
-    "_Genome",  ref$supp, ".fasta.fai"
+    "_Genome", ref$supp, ".fasta.fai"
   )
 )
 chrinfo <-
@@ -288,11 +292,11 @@ countalleles <- function(bamfile, vcf) {
         subjectHits()
     ]
     PosInSeq <- mapToAlignments(vcfgr, eventSeq)
-    refwidthDNA <- 
+    refwidthDNA <-
       subseq(mcols(eventSeq)$seq,
         start = start(PosInSeq),
         width = width(vcfgr$REF)
-    )
+      )
     altwidthDNA <- tryCatch(
       subseq(mcols(eventSeq)$seq,
         start = start(PosInSeq),
@@ -321,100 +325,100 @@ countalleles <- function(bamfile, vcf) {
   }) |> list_rbind()
 }
 
-if (nrow(snpCDS) > 0){
-    SNPalleleCounts <- map(
-        c(
-            paste0(samplesOI, "_nodup.bam"),
-            paste0(parentlist, "_nodup.bam")
-        ),
-        countalleles,
-        vcf = snpCDS
-    ) |>
-        list_rbind()
-    
-    if (nrow(SNPalleleCounts) > 1) {
-        SNPalleleCounts <- arrange(SNPalleleCounts, variant)
+if (nrow(snpCDS) > 0) {
+  SNPalleleCounts <- map(
+    c(
+      paste0(samplesOI, "_nodup.bam"),
+      paste0(parentlist, "_nodup.bam")
+    ),
+    countalleles,
+    vcf = snpCDS
+  ) |>
+    list_rbind()
+
+  if (nrow(SNPalleleCounts) > 1) {
+    SNPalleleCounts <- arrange(SNPalleleCounts, variant)
+  }
+  #### Annotate SNPs ####
+  #### Load genome and transcript db
+  transcriptdb <- file.path(
+    refDir,
+    paste0("PlasmoDB-", ref$version, "_Pfalciparum", ref$strain, "_txdb.sql")
+  )
+  txdb <- tryCatch(
+    txdb <- loadDb(transcriptdb),
+    error = function(e) {
+      stop(paste(e, "Filepath:", transcriptdb))
     }
-    #### Annotate SNPs ####
-    #### Load genome and transcript db
-    transcriptdb <- file.path(
-        refDir,
-        paste0("PlasmoDB-", ref$version, "_Pfalciparum", ref$strain, "_txdb.sql")
+  )
+  if (argv$refstrain == "Supp") {
+    library("BSgenome.PfalciparumNF54iGP",
+      character.only = TRUE
     )
-    txdb <- tryCatch(
-        txdb <- loadDb(transcriptdb),
-        error = function(e) {
-            stop(paste(e, "Filepath:", transcriptdb))
-        }
+    pfg <- get("BSgenome.PfalciparumNF54iGP")
+  } else {
+    library(paste0("BSgenome.Pfalciparum", ref$strain, ".PlasmoDB.", ref$version),
+      character.only = TRUE
     )
-    if (argv$refstrain == "Supp") {
-        library("BSgenome.PfalciparumNF54iGP",
-                character.only = TRUE
+    pfg <- get(paste0("BSgenome.Pfalciparum", ref$strain, ".PlasmoDB.", ref$version))
+  }
+
+  #### AA prediction for SNPs in CDS
+  AApred <- predictCoding(query = snpCDS, subject = txdb, seqSource = pfg)
+
+  #### SNPs in same codon
+  mcols(AApred)$warning <- NA
+  if (paste(AApred$CDSID, AApred$PROTEINLOC) |> unlist() |> n_distinct() <
+    length(AApred)
+  ) {
+    multihit <- which(mcols(AApred) |>
+      as.data.frame() |>
+      add_count(CDSID, PROTEINLOC) |>
+      dplyr::select(n) > 1)
+    mcols(AApred[multihit])$warning <- "multihit on codon"
+  }
+
+  #### Remove synonymous ####
+  AApred <- AApred[which(mcols(AApred)$CONSEQUENCE != "synonymous" |
+    !is.na(mcols(AApred)$warning))]
+  nonsynSNP <-
+    cbind(
+      as.data.frame(AApred) |> dplyr::select(-ALT),
+      data.frame(
+        SNP = names(AApred),
+        ALT = as.character(unlist(AApred$ALT)),
+        AAchanges = with(
+          AApred,
+          paste0(REFAA, PROTEINLOC, VARAA)
         )
-        pfg <- get("BSgenome.PfalciparumNF54iGP")
-    } else {
-        library(paste0("BSgenome.Pfalciparum", ref$strain, ".PlasmoDB.", ref$version),
-                character.only = TRUE
-        )
-        pfg <- get(paste0("BSgenome.Pfalciparum", ref$strain, ".PlasmoDB.", ref$version))
-    }
-    
-    #### AA prediction for SNPs in CDS
-    AApred <- predictCoding(query = snpCDS, subject = txdb, seqSource = pfg)
-    
-    #### SNPs in same codon
-    mcols(AApred)$warning <- NA
-    if (paste(AApred$CDSID, AApred$PROTEINLOC) |> unlist() |> n_distinct() <
-        length(AApred)
-    ) {
-        multihit <- which(mcols(AApred) |>
-                              as.data.frame() |>
-                              add_count(CDSID, PROTEINLOC) |>
-                              dplyr::select(n) > 1)
-        mcols(AApred[multihit])$warning <- "multihit on codon"
-    }
-    
-    #### Remove synonymous ####
-    AApred <- AApred[which(mcols(AApred)$CONSEQUENCE != "synonymous" |
-                               !is.na(mcols(AApred)$warning))]
-    nonsynSNP <-
-        cbind(
-            as.data.frame(AApred) |> dplyr::select(-ALT),
-            data.frame(
-                SNP = names(AApred),
-                ALT = as.character(unlist(AApred$ALT)),
-                AAchanges = with(
-                    AApred,
-                    paste0(REFAA, PROTEINLOC, VARAA)
-                )
-            )
-        ) |> dplyr::select(SNP, seqnames,
-                           pos = start, strand, REF, ALT, QUAL,
-                           AAchanges, REFCODON, VARCODON, warning
-        )
-    
-    if (all(is.na(nonsynSNP$warning))) {
-        nonsynSNP <- dplyr::select(nonsynSNP, !c(REFCODON, VARCODON, warning))
-    }
-    SNPdetails <- left_join(
-        nonsynSNP,
-        SNPalleleCounts |> mutate(
-            AltFrac = paste0(AltCount, "/", TotCount),
-            TotCount = NULL, RefCount = NULL, AltCount = NULL
-        ) |>
-            pivot_wider(
-                names_from = c(SampleName),
-                values_from = c(AltFrac),
-                names_prefix = "AF_"
-            ),
-        by = join_by("SNP" == "variant")
+      )
+    ) |> dplyr::select(SNP, seqnames,
+      pos = start, strand, REF, ALT, QUAL,
+      AAchanges, REFCODON, VARCODON, warning
+    )
+
+  if (all(is.na(nonsynSNP$warning))) {
+    nonsynSNP <- dplyr::select(nonsynSNP, !c(REFCODON, VARCODON, warning))
+  }
+  SNPdetails <- left_join(
+    nonsynSNP,
+    SNPalleleCounts |> mutate(
+      AltFrac = paste0(AltCount, "/", TotCount),
+      TotCount = NULL, RefCount = NULL, AltCount = NULL
     ) |>
-        dplyr::select(!SNP)
+      pivot_wider(
+        names_from = c(SampleName),
+        values_from = c(AltFrac),
+        names_prefix = "AF_"
+      ),
+    by = join_by("SNP" == "variant")
+  ) |>
+    dplyr::select(!SNP)
 } else {
-    SNPdetails <- data.frame(
-        seqnames = factor(), Gene = character(), pos = integer()
-        )
-    AApred <- GRanges()
+  SNPdetails <- data.frame(
+    seqnames = factor(), Gene = character(), pos = integer()
+  )
+  AApred <- GRanges()
 }
 
 #### Get gene details for indels and non-synonymous SNPs ####
@@ -428,6 +432,19 @@ if (nrow(indelGene) > 0) {
       select = "last"
     )
   ]
+  #### Get Alt allele fractions for indels from added geno fields ####
+  indels.AF <- left_join(
+    as.data.frame(geno(indelGene)$AD) |>
+      rownames_to_column(var = "variant") |>
+      pivot_longer(cols = !"variant", names_to = "SampleName", values_to = "AD"),
+    as.data.frame(geno(indelGene)$AF) |>
+      rownames_to_column(var = "variant") |>
+      pivot_longer(cols = !"variant", names_to = "SampleName", values_to = "DP"),
+  ) |> mutate(
+    AltFrac = paste0(AD, "/", DP),
+    AD = NULL, DP = NULL
+  )
+
   #### Get gene details for indels ####
   indels.Feat.df <- data.frame(
     rowRanges(indelGene)[, c("REF", "ALT", "QUAL")],
@@ -461,7 +478,7 @@ if (nrow(indelGene) > 0) {
   indels.Feat.df <- data.frame(Gene = character(), ALT = character())
 }
 
-## Report indels in gene regions
+## Report indels in gene regions as 2 tables: gene details and allele fractions
 write_tsv(
   indels.Feat.df,
   file.path(
@@ -469,6 +486,17 @@ write_tsv(
     paste0(
       argv$samplegroup,
       "genefiltIndels.tsv"
+    )
+  )
+)
+
+write_tsv(
+  indels.AF,
+  file.path(
+    varDir,
+    paste0(
+      argv$samplegroup,
+      "AFfiltIndels.tsv"
     )
   )
 )
@@ -498,16 +526,16 @@ geneDetail <- map(baseIDEvents, function(ID) {
   )
 }) |>
   list_rbind()
-if (nrow(geneDetail) > 0){
-    snps.Feat.df <- cbind(snps.Feat.df, geneDetail) |>
-        mutate(
-            Gene = case_when(
-                is.na(GeneName) ~ Description |>
-                    str_replace_all(pattern = "\\+", replacement = " "),
-                TRUE ~ GeneName
-            ),
-            GeneName = NULL, Description = NULL, ID = NULL
-        )
+if (nrow(geneDetail) > 0) {
+  snps.Feat.df <- cbind(snps.Feat.df, geneDetail) |>
+    mutate(
+      Gene = case_when(
+        is.na(GeneName) ~ Description |>
+          str_replace_all(pattern = "\\+", replacement = " "),
+        TRUE ~ GeneName
+      ),
+      GeneName = NULL, Description = NULL, ID = NULL
+    )
 }
 
 SNPdetails <- left_join(
@@ -533,7 +561,7 @@ events.stats.df <- data.frame(
 write_tsv(
   events.stats.df,
   file.path(
-      varDir, paste0(
+    varDir, paste0(
       argv$samplegroup, critSamplesSom,
       "plusstats.Qcrit", argv$QUALcrit, ".tsv"
     )

--- a/config/modules.config
+++ b/config/modules.config
@@ -57,7 +57,7 @@ process {
     withLabel: Gridss {
         cpus = 8
         time = '12h'
-        memory = { 20.GB * task.attempt }
+        memory = { 40.GB * task.attempt }
     }
     withLabel: Rfilter {
         cpus = 8

--- a/modules/stvariant.nf
+++ b/modules/stvariant.nf
@@ -1,5 +1,4 @@
 
-
 process Bcf{
     label 'Bcftools'
     tag "${groupId}"   
@@ -17,7 +16,7 @@ process Bcf{
     script:
     """
     bcftools mpileup -Ou --max-depth 800 --threads ${task.cpus}  \
-    -f ${ref}.fasta  \
+    -a AD,DP -f ${ref}.fasta  \
     --bam-list ${bamlist}  | \
     bcftools call --ploidy 1 --threads ${task.cpus} -mv -Ov  \
     --output "${groupId}.vcf" -


### PR DESCRIPTION
stvariant.nf: Add switches to bcftools mpileup to add fields AD, DP to output vcf.
filterBcfVcf.R: Use new fields to report AF. Old code using bam files kept as backup
Also increase initial GRIDSS memory to 40 GB to reduce number of retries 