### PR TITLE
fix RCopynum bug with multiple parents

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -174,19 +174,14 @@ workflow {
             .unique()
             .combine(merged_ch,by:0)
             .map{row -> if (row[0]) tuple(row[1],row[0],row[2],row[3],row[4])}
-            .join(bamlist_ch.map{gid,filepath ->
-                def fileLines = filepath.readLines() 
-                def fileContents = fileLines.join(' ') 
-                return tuple(gid, fileContents)  
-            })
             .combine(bam_ch.bamnodup,by:0)
-            .groupTuple(by:[0,1,2,3,4,5])
+            .groupTuple(by:[0,1,2,3,4])
             .ifEmpty {
                 error("""
                 Input to CopyNum Analysis is empty.
                 """)
             }
-            .set{copynum_input_ch}//Emits val(groupId),val(parentId),path(refpath),val(bsref),path(mergedparent), path(bamlistcontent), path(bams), val(dummy)
+            .set{copynum_input_ch}//Emits val(groupId),val(parentId),path(refpath),val(bsref),path(mergedparent), path(bams), val(dummy)
     
     copynum_ch=RCopyNum(copynum_input_ch
                             .combine(Channel.fromList( [params.bin_CNroi, params.bin_CNfull] ))

--- a/modules/stvariant.nf
+++ b/modules/stvariant.nf
@@ -106,7 +106,6 @@ process RCopyNum {
    
     tuple  val(groupId),val(parentId),path(refpath),val(bsref),
             path(mergedparent), 
-            val(bamfilenames), 
             path(bams), 
             val(bins),path(script)
 
@@ -118,7 +117,7 @@ process RCopyNum {
     Rscript --vanilla ${script} \
         --samplegroup ${groupId} \
         --parentId ${parentId} \
-        --bams "${bamfilenames}" \
+        --bams "${bams}" \
         --bin_in_kbases ${bins} \
         --refDir ${refpath}\
         --bsref ${bsref}


### PR DESCRIPTION
RCopyNum failed because it was using full bam-file list instead of (sample bams plus merged parent). This didn't show up with single parent sample as bam-file names coincided. 
This commit fixes the bug but the handling of parent bams is clumsy and should be improved in future update